### PR TITLE
Send integration results only to the target runtime bundle

### DIFF
--- a/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-starter-connector/pom.xml
@@ -47,6 +47,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/CloudConnectorIntegrationHandler.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/CloudConnectorIntegrationHandler.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.stereotype.Component;
 
 @Component
-@EnableBinding({CloudConnectorChannels.class, ProcessRuntimeChannels.class})
+@EnableBinding({ProcessRuntimeChannels.class})
 public class CloudConnectorIntegrationHandler {
 
 }

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSender.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSender.java
@@ -16,12 +16,11 @@
 
 package org.activiti.cloud.connectors.starter.channels;
 
-import org.springframework.cloud.stream.annotation.Output;
-import org.springframework.messaging.MessageChannel;
+import org.activiti.cloud.connectors.starter.model.IntegrationResultEvent;
+import org.springframework.messaging.Message;
 
-public interface CloudConnectorChannels {
-    String INTEGRATION_RESULT_PRODUCER = "integrationResultsProducer";
+public interface IntegrationResultSender {
 
-    @Output(INTEGRATION_RESULT_PRODUCER)
-    MessageChannel integrationResultProducer();
+    void send(Message<IntegrationResultEvent> message);
+
 }

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSenderImpl.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSenderImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.connectors.starter.channels;
+
+import org.activiti.cloud.connectors.starter.model.IntegrationResultEvent;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IntegrationResultSenderImpl implements IntegrationResultSender {
+
+    private final BinderAwareChannelResolver resolver;
+
+    public IntegrationResultSenderImpl(BinderAwareChannelResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void send(Message<IntegrationResultEvent> message) {
+
+        resolver.resolveDestination("integrationResult:" + message.getPayload().getTargetApplication()).send(message);
+
+    }
+
+}

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEvent.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEvent.java
@@ -30,6 +30,8 @@ public class IntegrationResultEvent {
 
     private String flowNodeId;
 
+    private String targetApplication;
+
     private Map<String, Object> variables;
 
     //used by json deserialization
@@ -70,6 +72,14 @@ public class IntegrationResultEvent {
 
     public void setFlowNodeId(String flowNodeId) {
         this.flowNodeId = flowNodeId;
+    }
+
+    public String getTargetApplication() {
+        return targetApplication;
+    }
+
+    public void setTargetApplication(String targetApplication) {
+        this.targetApplication = targetApplication;
     }
 
     @Override

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
@@ -18,18 +18,25 @@ package org.activiti.cloud.connectors.starter.model;
 
 import java.util.Map;
 
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
 public class IntegrationResultEventBuilder {
+
+    private final IntegrationRequestEvent requestEvent;
+
+    public static IntegrationResultEventBuilder resultFor(IntegrationRequestEvent requestEvent) {
+        return new IntegrationResultEventBuilder(requestEvent)
+                .withExecutionId(requestEvent.getExecutionId())
+                .withFlowNodeId(requestEvent.getFlowNodeId())
+                .withTargetApplication(requestEvent.getApplicationName());
+    }
 
     private IntegrationResultEvent integrationResultEvent;
 
-    private IntegrationResultEventBuilder() {
+    private IntegrationResultEventBuilder(IntegrationRequestEvent requestEvent) {
+        this.requestEvent = requestEvent;
         this.integrationResultEvent = new IntegrationResultEvent();
-    }
-
-    public static IntegrationResultEventBuilder resultFor(IntegrationRequestEvent requestEvent) {
-        return new IntegrationResultEventBuilder()
-                .withExecutionId(requestEvent.getExecutionId())
-                .withFlowNodeId(requestEvent.getFlowNodeId());
     }
 
     private IntegrationResultEventBuilder withExecutionId(String executionId) {
@@ -42,12 +49,26 @@ public class IntegrationResultEventBuilder {
         return this;
     }
 
+    private IntegrationResultEventBuilder withTargetApplication(String targetApplication) {
+        integrationResultEvent.setTargetApplication(targetApplication);
+        return this;
+    }
+
     public IntegrationResultEventBuilder withVariables(Map<String, Object> variables) {
         integrationResultEvent.setVariables(variables);
         return this;
     }
 
-    public IntegrationResultEvent build(){
+    public IntegrationResultEvent build() {
         return integrationResultEvent;
+    }
+
+    public Message<IntegrationResultEvent> buildMessage() {
+        return getMessageBuilder().build();
+    }
+
+    public MessageBuilder<IntegrationResultEvent> getMessageBuilder() {
+        return MessageBuilder.withPayload(integrationResultEvent).setHeader("targetApplication",
+                                                                            requestEvent.getApplicationName());
     }
 }

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
@@ -25,18 +25,18 @@ public class IntegrationResultEventBuilder {
 
     private final IntegrationRequestEvent requestEvent;
 
-    public static IntegrationResultEventBuilder resultFor(IntegrationRequestEvent requestEvent) {
-        return new IntegrationResultEventBuilder(requestEvent)
-                .withExecutionId(requestEvent.getExecutionId())
-                .withFlowNodeId(requestEvent.getFlowNodeId())
-                .withTargetApplication(requestEvent.getApplicationName());
-    }
-
     private IntegrationResultEvent integrationResultEvent;
 
     private IntegrationResultEventBuilder(IntegrationRequestEvent requestEvent) {
         this.requestEvent = requestEvent;
         this.integrationResultEvent = new IntegrationResultEvent();
+    }
+
+    public static IntegrationResultEventBuilder resultFor(IntegrationRequestEvent requestEvent) {
+        return new IntegrationResultEventBuilder(requestEvent)
+                .withExecutionId(requestEvent.getExecutionId())
+                .withFlowNodeId(requestEvent.getFlowNodeId())
+                .withTargetApplication(requestEvent.getApplicationName());
     }
 
     private IntegrationResultEventBuilder withExecutionId(String executionId) {

--- a/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSenderImplTest.java
+++ b/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultSenderImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.connectors.starter.channels;
+
+import org.activiti.cloud.connectors.starter.model.IntegrationResultEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class IntegrationResultSenderImplTest {
+
+    @InjectMocks
+    private IntegrationResultSenderImpl integrationResultSender;
+
+    @Mock
+    private BinderAwareChannelResolver resolver;
+
+    @Mock
+    private MessageChannel messageChannel;
+
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    @Test
+    public void sendShouldSendMessageBasedOnTheTargetApplication() throws Exception {
+        //given
+        given(resolver.resolveDestination("integrationResult:myApp")).willReturn(messageChannel);
+
+        IntegrationResultEvent integrationResultEvent = new IntegrationResultEvent();
+        integrationResultEvent.setTargetApplication("myApp");
+        Message<IntegrationResultEvent> message = MessageBuilder.withPayload(integrationResultEvent).build();
+
+        //when
+        integrationResultSender.send(message);
+
+        //then
+        verify(messageChannel).send(message);
+    }
+
+}

--- a/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilderTest.java
+++ b/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilderTest.java
@@ -18,7 +18,9 @@ package org.activiti.cloud.connectors.starter.model;
 
 import java.util.Collections;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.springframework.messaging.Message;
 
 import static org.activiti.test.Assertions.assertThat;
 
@@ -56,5 +58,24 @@ public class IntegrationResultEventBuilderTest {
                 .hasTargetApplication(APP_NAME)
                 .hasVariables(Collections.singletonMap(VAR,
                                                        VALUE));
+    }
+
+    @Test
+    public void shouldBuildMessageWithTargetApplicationHeader() throws Exception {
+        //given
+        IntegrationRequestEvent integrationRequestEvent = new IntegrationRequestEvent(PROC_INST_ID,
+                                                                                      PROC_DEF_ID,
+                                                                                      EXEC_ID,
+                                                                                      Collections.emptyMap());
+        integrationRequestEvent.setApplicationName(APP_NAME);
+
+        //when
+        Message<IntegrationResultEvent> message = IntegrationResultEventBuilder
+                .resultFor(integrationRequestEvent)
+                .buildMessage();
+
+        //then
+        Assertions.assertThat(message.getHeaders()).containsEntry("targetApplication",
+                                                                  APP_NAME);
     }
 }

--- a/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilderTest.java
+++ b/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.connectors.starter.model;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import static org.activiti.test.Assertions.assertThat;
+
+public class IntegrationResultEventBuilderTest {
+
+    private static final String PROC_INST_ID = "procInstId";
+    private static final String PROC_DEF_ID = "procDefId";
+    private static final String EXEC_ID = "execId";
+    private static final String FLOW_NODE_ID = "flowNodeId";
+    private static final String APP_NAME = "appName";
+    private static final String VAR = "var";
+    private static final String VALUE = "value";
+
+    @Test
+    public void shouldBuildIntegrationResultBasedOnInformationFromIntegrationRequest() throws Exception {
+        //given
+        IntegrationRequestEvent integrationRequestEvent = new IntegrationRequestEvent(PROC_INST_ID,
+                                                                                      PROC_DEF_ID,
+                                                                                      EXEC_ID,
+                                                                                      Collections.emptyMap());
+        integrationRequestEvent.setFlowNodeId(FLOW_NODE_ID);
+        integrationRequestEvent.setApplicationName(APP_NAME);
+
+        //when
+        IntegrationResultEvent resultEvent = IntegrationResultEventBuilder
+                .resultFor(integrationRequestEvent)
+                .withVariables(Collections.singletonMap(VAR,
+                                                        VALUE))
+                .build();
+
+        //then
+        assertThat(resultEvent)
+                .hasExecutionId(EXEC_ID)
+                .hasFlowNodeId(FLOW_NODE_ID)
+                .hasTargetApplication(APP_NAME)
+                .hasVariables(Collections.singletonMap(VAR,
+                                                       VALUE));
+    }
+}

--- a/activiti-cloud-starter-connector/src/test/resources/application.properties
+++ b/activiti-cloud-starter-connector/src/test/resources/application.properties
@@ -5,9 +5,6 @@ spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/
 spring.cloud.stream.bindings.integrationEventsProducer.destination=messages
 spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
 
-spring.cloud.stream.bindings.integrationResultsProducer.destination=notifications
-spring.cloud.stream.bindings.integrationResultsProducer.contentType=application/json
-
 spring.cloud.stream.bindings.integrationEventsConsumer.destination=messages
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
 spring.cloud.stream.bindings.runtimeCmdProducer.destination=commandConsumer


### PR DESCRIPTION
Use dynamic bound destinations to send integration requests only to the target runtime bundle:
- each integration request will bring the information about the source application name
- the target channel will be `IntegrationResult:<applicationName>`
- each runtime bundle should configure the `integrationResultsConsumer` channel as following:
`spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}`