### PR TITLE
Update copyright header

### DIFF
--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationRequestEvent.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationRequestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEvent.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
+++ b/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/RuntimeMockStreams.java
+++ b/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/RuntimeMockStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco and/or its affiliates.
+ * Copyright 2018 Alfresco and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- since a new year started the copyright year was updated to 2018

refs [#1686](https://github.com/Activiti/Activiti/issues/1686)