### PR TITLE
refactor(build); removed spring-boot-starter-web dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ after_failure:
   - cat **/target/surefire-reports/*.xml | grep -B 1 -A 10 "<error"
   - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 10 "<error"
 
-env:
-  global:
-  - DOCKER_HOST=tcp://127.0.0.1:2375
+# env:
+#   global:
+#   - DOCKER_HOST=tcp://127.0.0.1:2375

--- a/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-starter-connector/pom.xml
@@ -35,6 +35,18 @@
       <artifactId>activiti-cloud-services-monitoring</artifactId>
     </dependency>
     <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-services-common-security-keycloak</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-services-tracing</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-services-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-commons</artifactId>
     </dependency>
@@ -47,13 +59,12 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-starter-connector/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>spring-cloud-stream</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
@@ -50,10 +54,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
-    <activiti-cloud-service-common.version>7.1.67</activiti-cloud-service-common.version>
+    <activiti-cloud-service-common.version>7.1.68</activiti-cloud-service-common.version>
     <activiti-cloud-connectors.version>${project.version}</activiti-cloud-connectors.version>
   </properties>
   


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-service-common/pull/207

Fixes https://github.com/Activiti/Activiti/issues/1399