### PR TITLE
fix: Extracted external dependencies to root pom dependency management

### DIFF
--- a/activiti-cloud-connectors-dependencies/pom.xml
+++ b/activiti-cloud-connectors-dependencies/pom.xml
@@ -14,13 +14,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.cloud.common</groupId>
-        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
-        <version>${activiti-cloud-service-common.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.connector</groupId>
         <artifactId>activiti-cloud-starter-connector</artifactId>
         <version>${activiti-cloud-connectors.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+        <version>${activiti-cloud-service-common.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
This PR fixes activiti-cloud-runtime-bundle-dependencies management BoM to extract external dependencies BoMs into root pom dependency management section

Part of https://github.com/Activiti/Activiti/issues/3099